### PR TITLE
Set toolbar template and id for widget

### DIFF
--- a/trix/templates/trix/widget.html
+++ b/trix/templates/trix/widget.html
@@ -1,2 +1,3 @@
 {{ textarea }}
+{% if toolbar_template %}{% include toolbar_template with toolbar_id=toolbar_id %}{% endif %}
 <trix-editor {{ params }}></trix-editor>

--- a/trix/templates/trix/widget.html
+++ b/trix/templates/trix/widget.html
@@ -1,0 +1,2 @@
+{{ textarea }}
+<trix-editor {{ params }}></trix-editor>

--- a/trix/widgets.py
+++ b/trix/widgets.py
@@ -9,8 +9,10 @@ class TrixEditor(forms.Textarea):
     def __init__(self,
                  *args,
                  params={},
+                 toolbar_template=None,
                  **kwargs):
         self.params = params.copy()
+        self.toolbar_template = toolbar_template
         super(TrixEditor, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):
@@ -27,6 +29,13 @@ class TrixEditor(forms.Textarea):
                 self.params.get('class', '').split(' ') + ['trix-content']
             ),
         })
+        if self.toolbar_template:
+            self.params.update({
+                'toolbar': self.params.get(
+                    'toolbar',
+                    'trix-{name}-toolbar'.format(name=name)
+                )
+            })
 
         param_str = ' '.join('{}="{}"'.format(k, v)
                              for k, v in self.params.items())
@@ -38,6 +47,7 @@ class TrixEditor(forms.Textarea):
             context={
                 'toolbar_id': self.params.get('toolbar'),
                 'textarea': textarea,
+                'toolbar_template': self.toolbar_template,
                 'params': mark_safe(param_str),
             }
         )

--- a/trix/widgets.py
+++ b/trix/widgets.py
@@ -1,10 +1,17 @@
 from __future__ import unicode_literals
 from django import forms
-from django.utils.html import format_html
+from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
 
 class TrixEditor(forms.Textarea):
+
+    def __init__(self,
+                 *args,
+                 params={},
+                 **kwargs):
+        self.params = params.copy()
+        super(TrixEditor, self).__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None):
 
@@ -12,18 +19,28 @@ class TrixEditor(forms.Textarea):
             attrs = {}
         attrs.update({'style': 'visibility: hidden; position: absolute;'})
 
-        params = {
-            'input': attrs.get('id') or '{}_id'.format(name),
-            'class': 'trix-content',
-        }
-        param_str = ' '.join('{}="{}"'.format(k, v) for k, v in params.items())
+        self.params.update({
+            'input': (self.params.get('input') or
+                      attrs.get('id') or
+                      '{}_id'.format(name)),
+            'class': ' '.join(
+                self.params.get('class', '').split(' ') + ['trix-content']
+            ),
+        })
 
-        html = super(TrixEditor, self).render(name, value, attrs)
-        html = format_html(
-            '{}<p><trix-editor {}></trix-editor></p>',
-            html,
-            mark_safe(param_str))
-        return html
+        param_str = ' '.join('{}="{}"'.format(k, v)
+                             for k, v in self.params.items())
+
+        textarea = super(TrixEditor, self).render(name, value, attrs)
+
+        return render_to_string(
+            'trix/widget.html',
+            context={
+                'toolbar_id': self.params.get('toolbar'),
+                'textarea': textarea,
+                'params': mark_safe(param_str),
+            }
+        )
 
     class Media:
         css = {'all': ('trix/trix.css',)}

--- a/trix/widgets.py
+++ b/trix/widgets.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django import forms
-from django.contrib.admin import widgets as admin_widgets
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 


### PR DESCRIPTION
This feature allows to initialize the `TrixEditor` with arguments `params` and `toolbar_template`.

The `params` argument (a dict) is used to pass parameters to the `<trix-editor></trix-editor>` tag. Passing `params={'toolbar': 'my-custom-toolbar'}` will render a `<trix-editor toolbar="my-custom-toolbar" ... ></trix>`. This argument is optional and requires a corresponding `<trix-toolbar id="my-custom-toolbar">...</trix-toolbar>` in the document.

To allow further customization the argument `toolbar_template` is used. `toolbar_template` is a string to a django template. The toolbar template is included right before the `<trix-editor>...</trix-editor>` and a `toolbar_id` is passed to it (taken either from the `params` argument or created from the name of the rendered field).